### PR TITLE
fix: comma related issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/postcss-for",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "PostCSS plugin that enables SASS-like for loop syntax in your CSS",
   "keywords": [
     "postcss",

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,11 +130,11 @@ const plugin = (): Plugin => {
         vars({
           only: value,
         }),
-      ]).process(content.nodes);
+      ]).process(content.nodes.join(""));
 
       debug("newCSS.css", newCSS.css);
 
-      rule.parent.insertBefore(rule, newCSS.css.split(",@for").join("@for"));
+      rule.parent.insertBefore(rule, newCSS.css);
     }
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,13 @@ describe("utilitycss-postcss-for", function () {
     );
   });
 
+  it("it handles multiple selectors", async function () {
+    await test(
+      "@for $i from 1 to 2 { .b-$i {} .c-$i {} }",
+      ".b-1 {} .c-1 {}\n.b-2 {} .c-2 {}"
+    );
+  });
+
   it("it supports nested loops", async function () {
     await test(
       "@for $i from 1 to 2 { @for $j from 1 to 2 {.b-$(i)-$(j) {} } }",


### PR DESCRIPTION
@sylvesteraswin 

content.nodes being an array is getting converted to a string at some point in the var plugin and commas are added between nodes (default `Array.toString()` behavior)

joining the array as a single string before passing it down seems to work.
